### PR TITLE
Fix: Correct file path parsing in _fetch_printable_files_list

Modifies `coordinator.py` to improve the parsing of the `~M661` M-code
response for listing printable files.

Changes in `_fetch_printable_files_list`:
- Updated the path detection logic to search for `"/data/"` instead of
  `"//data/"` within response segments.
- Updated the validation logic to ensure cleaned file paths start with
  `"/data/"`.

This addresses an issue where files were being missed during parsing
due to variations in path prefixes (e.g., leading spaces or control
characters before `/data/`) in the M661 output, as identified from
your provided debug logs.

### DIFF
--- a/coordinator.py
+++ b/coordinator.py
@@ -87,15 +87,17 @@ class FlashforgeDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug(f"Splitting M661 payload with separator '{separator}'. Number of parts: {len(parts)}. First few parts if any: {parts[:5]}")
 
                 for part in parts:
-                    path_start_index = part.find("//data/")
-                    _LOGGER.debug(f"M661 parsing - Original part segment: '{part}', Found '//data/' at index {path_start_index}")
+                    path_start_index = part.find("/data/") # Changed from //data/
+                    _LOGGER.debug(f"M661 parsing - Original part segment: '{part}', Found '/data/' at index {path_start_index}")
                     if path_start_index != -1:
-                        file_path = part[path_start_index:]
-                        _LOGGER.debug(f"M661 parsing - Extracted file_path: '{file_path}'")
-                        if file_path:
+                        file_path = part[path_start_index:] # Path extracted from /data/ onwards
+                        _LOGGER.debug(f"M661 parsing - Extracted file_path candidate: '{file_path}'")
+                        if file_path: # file_path here is the candidate starting with /data/
+                            # Clean non-printable characters and trim whitespace from the candidate
                             cleaned_path = "".join(filter(lambda x: x.isprintable(), file_path)).strip()
-                            _LOGGER.debug(f"M661 parsing - Cleaned path: '{cleaned_path}', Ends with .gcode/.gx: {cleaned_path.endswith(('.gcode', '.gx'))}")
-                            if cleaned_path and cleaned_path.endswith((".gcode", ".gx")):
+                            _LOGGER.debug(f"M661 parsing - Cleaned path: '{cleaned_path}', Starts with /data/ and ends with .gcode/.gx: {cleaned_path.startswith('/data/') and cleaned_path.endswith(('.gcode', '.gx'))}")
+                            # Validate that the cleaned path still starts with /data/ and has a valid extension
+                            if cleaned_path.startswith("/data/") and cleaned_path.endswith((".gcode", ".gx")):
                                 files_list.append(cleaned_path)
 
                 if files_list:


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

