### PR TITLE
fix: printing binary sensor always off + speed adjustment reports 10000%

### DIFF
--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -305,7 +305,7 @@ class FlashforgeBinarySensor(FlashforgeEntity, BinarySensorEntity):
         # Printing status sensor (uses "detail" object)
         if self._is_printing_sensor:
             status = detail.get(API_ATTR_STATUS)
-            return status in PRINTING_STATES if status else False
+            return status.upper() in PRINTING_STATES if status else False
 
         # Connection status sensor
         if self._connection_status_sensor:

--- a/sensor.py
+++ b/sensor.py
@@ -267,7 +267,7 @@ SENSOR_DEFINITIONS = {
         None,
         SensorStateClass.MEASUREMENT,
         False,
-        True,
+        False,  # already a whole-number %, not a 0-1 fraction
     ),
     "printable_files": (
         "Printable Files Count",


### PR DESCRIPTION
## Summary

Two bugs identified by cross-referencing live HA sensor data against the integration source while building a calibration agent on top of this integration.

- **`binary_sensor.flashforge_printing` always reports `off` during active prints** — the `is_on` check compares the raw status string against `PRINTING_STATES` case-sensitively, but the printer returns lowercase `"printing"` while `PRINTING_STATES = ["BUILDING", "PRINTING", "RUNNING"]` is uppercase.
- **`sensor.flashforge_print_speed_adjustment` reports `10000` instead of `100`** — `printSpeedAdjust` is flagged as `is_percentage=True`, which causes `_handle_coordinator_update` to multiply the raw value by 100. But the printer sends `100` to mean 100% (a whole-number percentage), not `1.0` as a 0–1 fraction like `printProgress`. The `is_percentage` multiply-by-100 path is only correct for fractional values.

## Changes

### `binary_sensor.py`
```python
# Before
return status in PRINTING_STATES if status else False
# After
return status.upper() in PRINTING_STATES if status else False
```

### `sensor.py`
```python
# Before
"printSpeedAdjust": ("Print Speed Adjustment", PERCENTAGE, None, SensorStateClass.MEASUREMENT, False, True),
# After
"printSpeedAdjust": ("Print Speed Adjustment", PERCENTAGE, None, SensorStateClass.MEASUREMENT, False, False),
#                                                                                                       ^^^^^ was True
```

## Test plan

- [ ] Start a print and confirm `binary_sensor.flashforge_printing` transitions to `on`
- [ ] Confirm `sensor.flashforge_print_speed_adjustment` reports `100` at default speed (not `10000`)
- [ ] Confirm pausing/cancelling a print transitions the binary sensor back to `off`

🤖 Generated with [Claude Code](https://claude.com/claude-code)