### PR TITLE
fix(sensor): pin metric units, prevent HA imperial auto-conversion

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfMass,
     UnitOfLength,
+    UnitOfSpeed,
     UnitOfTime,
     UnitOfInformation,
     PERCENTAGE,
@@ -232,7 +233,7 @@ SENSOR_DEFINITIONS = {
     ),
     "currentPrintSpeed": (
         "Current Print Speed",
-        "mm/s",
+        UnitOfSpeed.MILLIMETERS_PER_SECOND,
         SensorDeviceClass.SPEED,
         SensorStateClass.MEASUREMENT,
         False,
@@ -372,6 +373,7 @@ class FlashforgeSensor(FlashforgeEntity, SensorEntity):
         self._attr_device_class = device_class
         self._attr_state_class = state_class
         self._attr_native_unit_of_measurement = PERCENTAGE if is_percentage else unit
+        self._attr_suggested_unit_of_measurement = PERCENTAGE if is_percentage else unit
         self._attr_extra_state_attributes: Dict[str, Any] = {}
         self._attr_native_value: Any = None
 


### PR DESCRIPTION
## Problem

When Home Assistant is configured with an imperial unit system, HA auto-converts sensors that have a matching `SensorDeviceClass`:

| Sensor | Declared | HA shows |
|--------|----------|----------|
| `currentPrintSpeed` | `mm/s` | `in/s` |
| `cumulativeFilament` | `m` | `ft` |
| Temperature sensors | `°C` | `°F` |

The printer is a metric device — its native values are already in the correct units. HA's auto-conversion produces confusing mixed-unit displays (e.g. speed in `in/s` while filament lengths stay in `mm`).

## Fix

### `suggested_unit_of_measurement`
Set `_attr_suggested_unit_of_measurement` equal to `native_unit_of_measurement` on every `FlashforgeSensor`. This tells HA to use the declared unit as the default display unit even on imperial systems. Users can still override individual entities in the HA UI if they prefer imperial.

```python
# One line added to FlashforgeSensor.__init__
self._attr_suggested_unit_of_measurement = PERCENTAGE if is_percentage else unit
```

### `UnitOfSpeed.MILLIMETERS_PER_SECOND`
Replace the raw `"mm/s"` string on `currentPrintSpeed` with the proper HA constant for consistency with the rest of the sensor definitions.

## Note on `printSpeedAdjust` still showing 10000

If the sensor still shows `10000` after merging PR #99, a **full HA restart** (not just an integration reload) is required to clear the cached entity state and apply the `is_percentage=False` change.

## Test plan

- [ ] After merging + full HA restart, confirm `sensor.flashforge_current_print_speed` displays `mm/s`
- [ ] Confirm `sensor.flashforge_cumulative_filament` displays `m` (not `ft`)
- [ ] Confirm temperature sensors display `°C`
- [ ] Confirm `sensor.flashforge_print_speed_adjustment` displays `100` at default speed

🤖 Generated with [Claude Code](https://claude.com/claude-code)